### PR TITLE
Build nmakehlp if necessary

### DIFF
--- a/win/makefile.vc
+++ b/win/makefile.vc
@@ -17,8 +17,15 @@
 PROJECT = tjson
 GENERICDIR = ..\src
 
+# Need nmakehlp to extract version number from cmake makefile.
+!if !EXISTS(nmakehlp.exe)
+!if [cl nmakehlp.c]
+!error *** Could not build nmakehlp.
+!endif
+!endif
+
 !if [echo DOTVERSION = \> versions.vc] \
-   || [.\nmakehlp -V ..\CMakeLists.txt tjson >> versions.vc]
+   || [nmakehlp -V ..\CMakeLists.txt tjson >> versions.vc]
 !error *** Could not figure out extension version. Please define DOTVERSION in parent makefile before including rules.vc.
 !endif
 

--- a/win/makefile.vc
+++ b/win/makefile.vc
@@ -51,13 +51,6 @@ PRJ_DEFINES = -D_CRT_SECURE_NO_WARNINGS -DTCL_NO_DEPRECATED -DVERSION=$(DOTVERSI
 DISABLE_TARGET_install = 1
 !include "$(_RULESDIR)\targets.vc"
 
-# Override binary installation directory
-!if "$(ARCH)" == "AMD64"
-BIN_INSTALL_DIR = $(SCRIPT_INSTALL_DIR)\win32-x86_64
-!else
-BIN_INSTALL_DIR = $(SCRIPT_INSTALL_DIR)\win32-ix86
-!endif
-
 install: pkgindex
 	@echo Installing to '$(SCRIPT_INSTALL_DIR)'
 	@if not exist "$(SCRIPT_INSTALL_DIR)" mkdir "$(SCRIPT_INSTALL_DIR)"


### PR DESCRIPTION
Sorry, my last pull request had a buglet. It expected the nmakehlp.exe executable to be in the path or current directory (which I have and why it worked on my system).

This patch will build the executable if not present.